### PR TITLE
Implement CMDLine parser for PatternGen Tool

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/PatternGen.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/PatternGen.cpp
@@ -533,7 +533,7 @@ generatePattern(MachineFunction &MF) {
 
   MachineBasicBlock &BB = *MF.begin();
   MachineRegisterInfo &MRI = MF.getRegInfo();
-  BB.dump();
+  // BB.dump();
 
   auto Instrs = BB.instr_rbegin();
   auto InstrsEnd = BB.instr_rend();

--- a/llvm/tools/pattern-gen/LLVMOverride.cpp
+++ b/llvm/tools/pattern-gen/LLVMOverride.cpp
@@ -60,7 +60,7 @@ more aggressively directly.
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/IPO.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+// #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/MC/TargetRegistry.h"
 #include <cctype>
 #define DEBUG_TYPE "isel"

--- a/llvm/tools/pattern-gen/LLVMOverride.hpp
+++ b/llvm/tools/pattern-gen/LLVMOverride.hpp
@@ -1,4 +1,4 @@
 #pragma once
 #include "llvm/IR/Module.h"
 
-int RunPatternGenPipeline(llvm::Module* M, std::string extName);
+int RunPatternGenPipeline(llvm::Module* M, std::string mattr, size_t opt_level);

--- a/llvm/tools/pattern-gen/Main.cpp
+++ b/llvm/tools/pattern-gen/Main.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <tuple>
 #include <memory>
+#include <filesystem>
 
 #include "lib/InstrInfo.hpp"
 #include "lib/Parser.hpp"
@@ -21,40 +22,122 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/CommandLine.h"
 
-static auto get_out_streams (std::string srcPath)
+using namespace llvm;
+
+
+static cl::OptionCategory ToolOptions("Tool Options");
+static cl::OptionCategory ViewOptions("View Options");
+
+static cl::opt<std::string> InputFilename(cl::Positional,
+                                          cl::desc("<input file>"),
+                                          cl::cat(ToolOptions), cl::init("-"));
+
+static cl::opt<std::string> OutputFilename("o", cl::desc("Output filename"),
+                                           cl::init("-"), cl::cat(ToolOptions),
+                                           cl::value_desc("filename"));
+
+static cl::opt<std::string> InputLanguage("x", cl::desc("Input language ('cdsl' or 'll')"), cl::cat(ToolOptions));
+
+static cl::opt<bool> Force ("f", cl::desc("Ignore parser errors."), cl::cat(ToolOptions));
+static cl::opt<bool> Skip ("s", cl::desc("Skip pattern-gen step."), cl::cat(ToolOptions));
+
+static cl::opt<std::string> ExtName("ext", cl::desc("Target extension"), cl::cat(ToolOptions), cl::init("Xcvsimd"));
+static cl::opt<std::string> Mattr("mattr2", cl::desc("Target specific attributes"), cl::value_desc("a1,+a2,-a3,..."), cl::cat(ToolOptions), cl::init("+m,+unaligned-scalar-mem,+xcvalu,+xcvsimd"));
+
+// Determine optimization level.
+static cl::opt<char>
+    OptLevel("O",
+             cl::desc("Optimization level. [-O0, -O1, -O2, or -O3] "
+                      "(default = '-O2')"),
+             cl::cat(ToolOptions), cl::init('3'));
+
+#include <iostream>
+namespace fs = std::filesystem;
+
+static auto get_out_streams (std::string srcPath, std::string destPath)
 {
-    std::string outPath{srcPath};
-    const char type[] = ".core_desc";
-    if (outPath.find(type, outPath.size() - sizeof(type)))
-        outPath = outPath.substr(0, outPath.size() - sizeof(type) + 1);
-    return std::make_tuple(std::ofstream(outPath + "InstrFormat.td"), std::ofstream(outPath + ".td"));
+    fs::path outPath{destPath};
+    std::string ext = outPath.extension();
+    std::string stem = outPath.stem();
+    // std::string name = outPath.filename();
+    fs::path parent = outPath.parent_path();
+    // std::cout << "outPath=" << outPath << "!" << std::endl;
+    // std::cout << "ext=" <<  ext << "!" << std::endl;
+    // std::cout << "stem=" <<  stem << "!" << std::endl;
+    // std::cout << "name=" <<  name << "!" << std::endl;
+    // std::cout << "parent=" <<  parent << "!" << std::endl;
+    fs::path inPath{srcPath};
+    std::string ext2 = inPath.extension();
+    std::string stem2 = inPath.stem();
+    // std::string name2 = inPath.filename();
+    fs::path parent2 = inPath.parent_path();
+    // std::cout << "inPath2=" << inPath << "!" << std::endl;
+    // std::cout << "ext2=" <<  ext2 << "!" << std::endl;
+    // std::cout << "stem2=" <<  stem2 << "!" << std::endl;
+    // std::cout << "name2=" <<  name2 << "!" << std::endl;
+    // std::cout << "parent2=" <<  parent2 << "!" << std::endl;
+    fs::path basePath = parent2 / stem2;
+    std::string newExt = ".td";
+    if (outPath.compare("-") != 0) {
+        basePath = parent / stem;
+        newExt = ext;
+    }
+    // TODO: allow .td in out path
+    std::string irPath = basePath.string() + ".ll";
+    std::string fmtPath = basePath.string() + "InstrFormat" + newExt;
+    std::string patPath = basePath.string() + newExt;
+    // std::cout << "basePath=" << basePath << "!" << std::endl;
+    // std::cout << "newExt=" << newExt << "!" << std::endl;
+    // std::cout << "irPath=" << irPath << "!" << std::endl;
+    // std::cout << "fmtPath=" << fmtPath << "!" << std::endl;
+    // std::cout << "patPath=" << patPath << "!" << std::endl;
+    return std::make_tuple(std::ofstream(irPath), std::ofstream(fmtPath), std::ofstream(patPath));
 }
+
 
 int main (int argc, char** argv)
 {
+    cl::HideUnrelatedOptions({&ToolOptions, &ViewOptions});
+    cl::ParseCommandLineOptions(argc, argv, "CoreDSL2LLVM Pattern Gen");
     if (argc <= 1)
     {
         fprintf(stderr, "usage: %s <SOURCE FILE> LLVM-ARGS...\n", argv[0]);
         return -1;
     }
 
-    const char* srcPath = argv[1];
+    // const char* srcPath = argv[1];
 
-    auto [formatOut, patternOut] = get_out_streams(srcPath);
+    auto [irOut, formatOut, patternOut] = get_out_streams(InputFilename, OutputFilename);
 
-    TokenStream ts(srcPath);
-    llvm::LLVMContext ctx;
-    auto mod = std::make_unique<llvm::Module>("mod", ctx);
+    TokenStream ts(InputFilename.c_str());
+    LLVMContext ctx;
+    auto mod = std::make_unique<Module>("mod", ctx);
     auto instrs = ParseCoreDSL2(ts, mod.get());
 
-    PrintInstrsAsTableGen(instrs, formatOut);
 
-    llvm::outs() << *mod << "\n";
-    if (llvm::verifyModule(*mod, &llvm::errs()))
+    if (irOut) {
+        // outs() << *mod << "\n";
+        std::string Str;
+        raw_string_ostream OS(Str);
+        OS << *mod;
+        OS.flush();
+        irOut << Str << "\n";
+        irOut.close();
+    }
+    if (verifyModule(*mod, &errs()))
         return -1;
-    
-    std::string extName = (argc > 2) ? argv[2] : "Xcvsimd"; 
 
-    GeneratePatterns(mod.get(), instrs, patternOut, extName);
+    // TODO: use opt_level
+    // TODO: use force
+    // TODO: write ll to file
+    // TODO: print optimized llvm ir
+
+    if (!Skip) {
+        PrintInstrsAsTableGen(instrs, formatOut);
+        // std::string extName = (argc > 2) ? argv[2] : "Xcvsimd";
+
+        GeneratePatterns(mod.get(), instrs, patternOut, ExtName, OptLevel, Mattr);
+    }
 }

--- a/llvm/tools/pattern-gen/PatternGen.cpp
+++ b/llvm/tools/pattern-gen/PatternGen.cpp
@@ -31,7 +31,7 @@ static std::string* extName = nullptr;
 using namespace llvm;
 using SVT = llvm::MVT::SimpleValueType;
 
-int GeneratePatterns(llvm::Module* M, std::vector<CDSLInstr> const& instrs, std::ostream& ostream, std::string extName)
+int GeneratePatterns(llvm::Module* M, std::vector<CDSLInstr> const& instrs, std::ostream& ostream, std::string extName, size_t opt_level, std::string mattr)
 {
     // All other code in this file is called during code generation
     // by the LLVM pipeline. We thus "pass" arguments as globals in this TU.
@@ -39,7 +39,7 @@ int GeneratePatterns(llvm::Module* M, std::vector<CDSLInstr> const& instrs, std:
     cdslInstrs = &instrs;
     ::extName = &extName;
 
-    int rv = RunPatternGenPipeline(M, extName);
+    int rv = RunPatternGenPipeline(M, mattr, opt_level);
 
     outStream = nullptr;
     cdslInstrs = nullptr;

--- a/llvm/tools/pattern-gen/PatternGen.hpp
+++ b/llvm/tools/pattern-gen/PatternGen.hpp
@@ -3,5 +3,5 @@
 #include "llvm/CodeGen/SelectionDAG.h"
 #include <llvm/IR/Module.h>
 
-int GeneratePatterns(llvm::Module* M, std::vector<CDSLInstr> const& instrs, std::ostream& ostream, std::string extName);
+int GeneratePatterns(llvm::Module* M, std::vector<CDSLInstr> const& instrs, std::ostream& ostream, std::string extName, size_t opt_level, std::string mattr);
 //void PrintPattern(llvm::SelectionDAG& DAG);


### PR DESCRIPTION
Also contains fixes for the issues raised earlier this week…

Output of `pattern-gen --help`:
```
USAGE: pattern-gen [options] <input file>

OPTIONS:

Generic Options:

  --help                    - Display available options (--help-hidden for more)
  --help-list               - Display list of available options (--help-list-hidden for more)
  --version                 - Display the version of this program

Tool Options:

  -O <char>                 - Optimization level. [-O0, -O1, -O2, or -O3] (default = '-O2')
  --ext=<string>            - Target extension
  -f                        - Ignore parser errors.
  --mattr2=<a1,+a2,-a3,...> - Target specific attributes
  -o <filename>             - Output filename
  -s                        - Skip pattern-gen step.
  -x <string>               - Input language ('cdsl' or 'll')
  ```